### PR TITLE
Prevent security to persist in memory

### DIFF
--- a/security/selinux/hooks.c
+++ b/security/selinux/hooks.c
@@ -4944,7 +4944,7 @@ static int selinux_tun_dev_alloc_security(void **security)
 
 static void selinux_tun_dev_free_security(void *security)
 {
-	kfree(security);
+	kzfree(security);
 }
 
 static int selinux_tun_dev_create(void)


### PR DESCRIPTION
security contains a lot of sensitive information. It cannot be allowed to persist in memory after a kfree. 